### PR TITLE
Make it so daos can be injected by subclasses.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.egg-info
 *.o
 *~
+.coverage
+.idea
+tests.log

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 lxml
-python-dateutil>=2.1
-urllib3>=1.9
+python-dateutil
+urllib3
+six
 jinja2
 nose
 mock

--- a/resttools/gws.py
+++ b/resttools/gws.py
@@ -25,6 +25,7 @@ class GWS(object):
         self._j2env = Environment(loader=PackageLoader('resttools',
                                                        'templates/gws'))
         self._actas = actas
+        self.dao = GWS_DAO(conf)
 
     QTRS = {'win': 'winter', 'spr': 'spring', 'sum': 'summer', 'aut': 'autumn'}
 
@@ -62,9 +63,8 @@ class GWS(object):
         if "instructor" in kwargs or "student" in kwargs:
             kwargs["stem"] = "course"
 
-        dao = GWS_DAO(self._conf)
         url = "/group_sws/v2/search?" + urlencode(kwargs)
-        response = dao.getURL(url, self._headers({"Accept": "text/xml"}))
+        response = self.dao.getURL(url, self._headers({"Accept": "text/xml"}))
 
         if response.status != 200:
             raise DataFailureException(url, response.status, response.data)
@@ -90,9 +90,8 @@ class GWS(object):
         if not self._is_valid_group_id(group_id):
             raise InvalidGroupID(group_id)
 
-        dao = GWS_DAO(self._conf)
         url = "/group_sws/v2/group/%s" % group_id
-        response = dao.getURL(url, self._headers({"Accept": "text/xml"}))
+        response = self.dao.getURL(url, self._headers({"Accept": "text/xml"}))
 
         if response.status != 200:
             raise DataFailureException(url, response.status, response.data)
@@ -105,12 +104,10 @@ class GWS(object):
         """
         body = self._xml_from_group(group)
 
-        dao = GWS_DAO(self._conf)
         url = "/group_sws/v2/group/%s" % group.name
-        response = dao.putURL(url,
-                              self._headers({"Accept": "text/xml",
-                                             "Content-Type": "text/xml"}),
-                              body)
+        response = self.dao.putURL(
+            url, self._headers({"Accept": "text/xml", "Content-Type": "text/xml"}),
+            body)
 
         if response.status != 201:
             raise DataFailureException(url, response.status, response.data)
@@ -123,13 +120,11 @@ class GWS(object):
         """
         body = self._xml_from_group(group)
 
-        dao = GWS_DAO(self._conf)
         url = "/group_sws/v2/group/%s" % group.name
-        response = dao.putURL(url,
-                              self._headers({"Accept": "text/xml",
-                                             "Content-Type": "text/xml",
-                                             "If-Match": "*"}),
-                              body)
+        response = self.dao.putURL(
+            url, self._headers({"Accept": "text/xml",
+                                "Content-Type": "text/xml", "If-Match": "*"}),
+            body)
 
         if response.status != 200:
             raise DataFailureException(url, response.status, response.data)
@@ -143,9 +138,8 @@ class GWS(object):
         if not self._is_valid_group_id(group_id):
             raise InvalidGroupID(group_id)
 
-        dao = GWS_DAO(self._conf)
         url = "/group_sws/v2/group/%s" % group_id
-        response = dao.deleteURL(url, self._headers({}))
+        response = self.dao.deleteURL(url, self._headers({}))
 
         if response.status != 200:
             raise DataFailureException(url, response.status, response.data)
@@ -160,9 +154,8 @@ class GWS(object):
         if not self._is_valid_group_id(group_id):
             raise InvalidGroupID(group_id)
 
-        dao = GWS_DAO(self._conf)
         url = "/group_sws/v2/group/%s/member" % group_id
-        response = dao.getURL(url, self._headers({"Accept": "text/xml"}))
+        response = self.dao.getURL(url, self._headers({"Accept": "text/xml"}))
 
         if response.status != 200:
             raise DataFailureException(url, response.status, response.data)
@@ -180,12 +173,10 @@ class GWS(object):
 
         body = self._xml_from_members(group_id, members)
 
-        dao = GWS_DAO(self._conf)
         url = "/group_sws/v2/group/%s/member" % group_id
-        response = dao.putURL(url,
-                              self._headers({"Content-Type": "text/xml",
-                                             "If-Match": "*"}),
-                              body)
+        response = self.dao.putURL(
+            url, self._headers({"Content-Type": "text/xml", "If-Match": "*"}),
+            body)
 
         if response.status != 200:
             raise DataFailureException(url, response.status, response.data)
@@ -204,12 +195,10 @@ class GWS(object):
         if len(members) == 0:
             return []
 
-        dao = GWS_DAO(self._conf)
         url = "/group_sws/v2/group/%s/member/%s" % (group_id, ','.join(members))
-        response = dao.putURL(url,
-                              self._headers({"Content-Type": "text/xml",
-                                             "If-Match": "*"}),
-                              None)
+        response = self.dao.putURL(
+            url, self._headers({"Content-Type": "text/xml", "If-Match": "*"}),
+            None)
 
         if response.status != 200:
             raise DataFailureException(url, response.status, response.data)
@@ -228,9 +217,9 @@ class GWS(object):
         if len(members) == 0:
             return True
 
-        dao = GWS_DAO(self._conf)
         url = "/group_sws/v2/group/%s/member/%s" % (group_id, ','.join(members))
-        response = dao.deleteURL(url, self._headers({"Content-Type": "text/xml", "If-Match": "*"}))
+        response = self.dao.deleteURL(url, self._headers(
+            {"Content-Type": "text/xml", "If-Match": "*"}))
 
         if response.status != 200:
             raise DataFailureException(url, response.status, response.data)
@@ -245,9 +234,8 @@ class GWS(object):
         if not self._is_valid_group_id(group_id):
             raise InvalidGroupID(group_id)
 
-        dao = GWS_DAO(self._conf)
         url = "/group_sws/v2/group/%s/effective_member" % group_id
-        response = dao.getURL(url, self._headers({"Accept": "text/xml"}))
+        response = self.dao.getURL(url, self._headers({"Accept": "text/xml"}))
 
         if response.status != 200:
             raise DataFailureException(url, response.status, response.data)
@@ -262,9 +250,8 @@ class GWS(object):
         if not self._is_valid_group_id(group_id):
             raise InvalidGroupID(group_id)
 
-        dao = GWS_DAO(self._conf)
         url = "/group_sws/v2/group/%s/effective_member?view=count" % group_id
-        response = dao.getURL(url, self._headers({"Accept": "text/xml"}))
+        response = self.dao.getURL(url, self._headers({"Accept": "text/xml"}))
 
         if response.status != 200:
             raise DataFailureException(url, response.status, response.data)
@@ -284,9 +271,8 @@ class GWS(object):
         # GWS doesn't accept EPPNs on effective member checks, for UW users
         netid = re.sub('@washington.edu', '', netid)
 
-        dao = GWS_DAO(self._conf)
         url = "/group_sws/v2/group/%s/effective_member/%s" % (group_id, netid)
-        response = dao.getURL(url, self._headers({"Accept": "text/xml"}))
+        response = self.dao.getURL(url, self._headers({"Accept": "text/xml"}))
 
         if response.status == 404:
             return False
@@ -311,7 +297,8 @@ class GWS(object):
             group.instructors = []
             instructors = (gr.find('course_instructors').findall('course_instructor'))
             for instructor in instructors:
-                group.instructors.append(GroupMember(name=instructor.text, member_type="uwnetid"))
+                group.instructors.append(GroupMember(name=instructor.text,
+                                                     member_type="uwnetid"))
         else:
             group = Group()
 

--- a/resttools/ntfyws.py
+++ b/resttools/ntfyws.py
@@ -11,14 +11,12 @@ class NTFYWS(object):
 
     def __init__(self, conf, actas=None):
         self._service_name = conf['SERVICE_NAME']
-        self._conf = conf
+        self.dao = NTFYWS_DAO(conf)
 
     def send_message(self, eppn, number, message, type='text'):
         """
         Sends a text (or voice) message to the phone number
         """
-        dao = NTFYWS_DAO(self._conf)
-
         if type == 'text':
             mtype = 'uw_direct_phone_sms'
             ts = 'Text'
@@ -37,6 +35,6 @@ class NTFYWS(object):
         }}
 
         url = "/%s/v1/dispatch" % (self._service_name)
-        resp = dao.postURL(url, {"Content-Type": "application/json"}, json.dumps(data))
+        resp = self.dao.postURL(url, {"Content-Type": "application/json"}, json.dumps(data))
 
         return resp.status

--- a/resttools/nws.py
+++ b/resttools/nws.py
@@ -24,19 +24,17 @@ class NWS(object):
         service_name = conf['SERVICE_NAME']
         version = conf.get('VERSION', 'v1')
         self._base_url = '/{}/{}'.format(service_name, version)
-        self._conf = conf
         self._pw_action = 'Set'
         if 'PASSWORD_ACTION' in conf:
             self._pw_action = conf['PASSWORD_ACTION']
+        self.dao = NWS_DAO(conf)
 
     def get_netid_admins(self, netid):
         """
         Returns a list of NetidAdmin objects for the netid
         """
-
-        dao = NWS_DAO(self._conf)
         url = "%s/uwnetid/%s/admin" % (self._base_url, quote_plus(netid))
-        response = dao.getURL(url, self._headers({"Accept": "application/json"}))
+        response = self.dao.getURL(url, self._headers({"Accept": "application/json"}))
 
         if response.status != 200:
             raise DataFailureException(url, response.status, response.data)
@@ -47,10 +45,8 @@ class NWS(object):
         """
         Returns NetidPwINfo object for the netid
         """
-
-        dao = NWS_DAO(self._conf)
         url = "%s/uwnetid/%s/password" % (self._base_url, quote_plus(netid))
-        response = dao.getURL(url, self._headers({"Accept": "application/json"}))
+        response = self.dao.getURL(url, self._headers({"Accept": "application/json"}))
 
         if response.status != 200:
             raise DataFailureException(url, response.status, response.data)
@@ -65,10 +61,9 @@ class NWS(object):
         if action is None:
             action = self._pw_action
 
-        dao = NWS_DAO(self._conf)
         url = "%s/uwnetid/%s/password" % (self._base_url, quote_plus(netid))
         data = {'action': action, 'newPassword': password, 'uwNetID': netid, 'authMethod': auth}
-        response = dao.postURL(url, {"Content-type": "application/json"}, json.dumps(data))
+        response = self.dao.postURL(url, {"Content-type": "application/json"}, json.dumps(data))
 
         if response.status >= 500:
             raise DataFailureException(url, response.status, response.data)

--- a/resttools/test/nws.py
+++ b/resttools/test/nws.py
@@ -1,5 +1,4 @@
 import json
-import logging
 from nose.tools import *
 from mock import patch
 
@@ -29,7 +28,8 @@ class NWS_Test():
             mock_response = nws_dao.return_value.getURL.return_value
             mock_response.status = 200
             mock_response.data = json.dumps({"timeStamp": "now", "uwNetID": "joe"})
-            eq_(self.nws.get_netid_admins('joe'), [])
+            nws = NWS(settings.NWS_CONF)
+            eq_(nws.get_netid_admins('joe'), [])
 
     def test_get_netid_pw(self):
         pw = self.nws.get_netid_pwinfo('groups')

--- a/setup.py
+++ b/setup.py
@@ -5,5 +5,5 @@ setup(name='resttools',
       description='UW-IT REST library',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['lxml', 'python-dateutil', 'urllib3', 'jinja2']
+      install_requires=['lxml', 'python-dateutil', 'urllib3', 'jinja2', 'six']
       )


### PR DESCRIPTION
In identity-uw we use the requests library for our backend, and for mocks we have a mock http that isn't file-based. This change allows us to subclass the main classes (IRWS, NWS) and use our own dao so we don't need to manage two sets of mock data. When complete, everything in dao_implementation will be unused by identity-uw. 